### PR TITLE
Fix issue when there are no candidates

### DIFF
--- a/fish-completion.el
+++ b/fish-completion.el
@@ -168,9 +168,8 @@ The candidates include the description."
 (defun fish-completion--list-completions (raw-prompt)
   "Return list of completion candidates for RAW-PROMPT."
   (mapcar (lambda (e) (car (split-string e "\t")))
-          (split-string
-           (fish-completion--list-completions-with-desc raw-prompt)
-           "\n" t)))
+          (let ((candidates (fish-completion--list-completions-with-desc raw-prompt)))
+            (when candidates (split-string candidates "\n" t)))))
 
 (defun fish-completion--maybe-use-bash (comp-list)
   "If COMP-LIST is empty, return a completion list with Bash.


### PR DESCRIPTION
I was getting a lot of `(wrong-type-argument stringp nil)` when trying to complete on say "find-file" in eshell using doom. I think this error was preventing the default pcomplete completions from running. Adding this simple clause seemed to fix the issue for me.